### PR TITLE
BREAKING CHANGE: Category is now an object instead of a simple string

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,9 +8,9 @@
 		<Nullable>enable</Nullable>
 		
 		<!-- NuGet -->
-		<Version>1.1.1</Version>
-		<AssemblyVersion>1.0.0.0</AssemblyVersion>
-		<FileVersion>1.0.0.0</FileVersion>
+		<Version>2.0.0-alpha1</Version>
+		<AssemblyVersion>2.0.0.0</AssemblyVersion>
+		<FileVersion>2.0.0.0</FileVersion>
 		<Authors>Armin Reiter; Jon Sagara</Authors>
 		<Copyright>Copyright 2022-2024</Copyright>
 		<RepositoryUrl>https://github.com/jonsagara/Sagara.FeedReader</RepositoryUrl>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
 		<Nullable>enable</Nullable>
 		
 		<!-- NuGet -->
-		<Version>2.0.0-alpha1</Version>
+		<Version>2.0.0</Version>
 		<AssemblyVersion>2.0.0.0</AssemblyVersion>
 		<FileVersion>2.0.0.0</FileVersion>
 		<Authors>Armin Reiter; Jon Sagara</Authors>

--- a/src/Sagara.FeedReader.Tests.Unit/FullParseTest.cs
+++ b/src/Sagara.FeedReader.Tests.Unit/FullParseTest.cs
@@ -246,7 +246,7 @@ public class FullParseTest
         Assert.Equal("Mon, 30 Sep 2002 11:00:00 GMT", feed.LastBuildDateString);
         Assert.Equal("http://backend.userland.com/rss", feed.Docs);
         Assert.Equal("Radio UserLand v8.0.5", feed.Generator);
-        Assert.Equal("1765", feed.Categories.First());
+        Assert.Equal("1765", feed.Categories.Select(r2fc => r2fc.Content!).First());
         Assert.Equal("dave@userland.com", feed.ManagingEditor);
         Assert.Equal("dave@userland.com", feed.WebMaster);
         Assert.Equal("40", feed.TTL);
@@ -285,7 +285,7 @@ public class FullParseTest
         Assert.Equal(new DateTime(2016, 12, 22, 7, 0, 28), item.PublishingDate);
         Assert.Equal("Armin Reiter", item.DC!.Creator);
         Assert.Equal(4, item.Categories.Count);
-        Assert.Contains("BillingAPI", item.Categories);
+        Assert.Contains("BillingAPI", item.Categories.Select(r2fc => r2fc.Content!));
         Assert.Equal("https://codehollow.com/?p=749", item.Guid);
         Assert.StartsWith("<p>The Azure Billing API allows to programmatically read Azure", item.Description);
         Assert.Contains("<add key=\"Tenant\" ", item.Content);

--- a/src/Sagara.FeedReader/Extensions/ICollectionExtensions.cs
+++ b/src/Sagara.FeedReader/Extensions/ICollectionExtensions.cs
@@ -8,7 +8,7 @@ public static class ICollectionExtensions
     /// <summary>
     /// Add a range of values to the collection.
     /// </summary>
-    public static void AddRange<T>(this ICollection<T> source, IReadOnlyCollection<T> valuesToAdd)
+    public static void AddRange<T>(this ICollection<T> source, IEnumerable<T> valuesToAdd)
     {
         ArgumentNullException.ThrowIfNull(source);
         ArgumentNullException.ThrowIfNull(valuesToAdd);

--- a/src/Sagara.FeedReader/Feeds/2.0/Rss20Feed.cs
+++ b/src/Sagara.FeedReader/Feeds/2.0/Rss20Feed.cs
@@ -67,7 +67,7 @@ public class Rss20Feed : BaseFeed
     /// <summary>
     /// All "category" elements
     /// </summary>
-    public IReadOnlyCollection<string> Categories { get; private set; } = Array.Empty<string>();
+    public IReadOnlyCollection<Rss20FeedCategory> Categories { get; private set; } = Array.Empty<Rss20FeedCategory>();
 
     /// <summary>
     /// The "generator" element
@@ -133,7 +133,11 @@ public class Rss20Feed : BaseFeed
         LastBuildDateString = channel.GetChildElementValue("lastBuildDate");
         ParseDates(Language, PublishingDateString, LastBuildDateString);
 
-        Categories = channel.GetElements("category").Select(ce => ce.Value).ToArray();
+        Categories = channel
+            .GetElements("category")
+            .Select(ce => new Rss20FeedCategory(ce))
+            .Where(r2fc => !string.IsNullOrWhiteSpace(r2fc.Content))
+            .ToArray();
 
         Sy = new Syndication(channel);
         Generator = channel.GetChildElementValue("generator");

--- a/src/Sagara.FeedReader/Feeds/2.0/Rss20FeedCategory.cs
+++ b/src/Sagara.FeedReader/Feeds/2.0/Rss20FeedCategory.cs
@@ -1,0 +1,41 @@
+﻿using System.Xml.Linq;
+using Sagara.FeedReader.Extensions;
+
+namespace Sagara.FeedReader.Feeds;
+
+/// <summary>
+/// RSS 2.0 feed category according to specification: https://validator.w3.org/feed/docs/rss2.html
+/// </summary>
+public class Rss20FeedCategory : BaseFeedCategory
+{
+    /// <summary>
+    /// Optional. Identifies the taxonomy in which the category is placed. Comes from the domain attribute.
+    /// </summary>
+    public string? Domain { get; set; }
+
+    /// <summary>
+    /// The category text pull from the tag's content.
+    /// </summary>
+    public string? Content { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Rss20FeedCategory"/> class.
+    /// default constructor (for serialization)
+    /// </summary>
+    public Rss20FeedCategory()
+        : base()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Rss20FeedCategory"/> class.
+    /// Reads a new feed category element based on the given xml item.
+    /// </summary>
+    /// <param name="categoryElement">The xml containing the feed item</param>
+    public Rss20FeedCategory(XElement categoryElement)
+        : base(categoryElement)
+    {
+        Domain = categoryElement.GetAttributeValue("domain");
+        Content = categoryElement.Value;
+    }
+}

--- a/src/Sagara.FeedReader/Feeds/2.0/Rss20FeedItem.cs
+++ b/src/Sagara.FeedReader/Feeds/2.0/Rss20FeedItem.cs
@@ -53,7 +53,7 @@ public class Rss20FeedItem : BaseFeedItem
     /// <summary>
     /// All entries "category" entries
     /// </summary>
-    public IReadOnlyCollection<string> Categories { get; private set; } = Array.Empty<string>();
+    public IReadOnlyCollection<Rss20FeedCategory> Categories { get; private set; } = Array.Empty<Rss20FeedCategory>();
 
     /// <summary>
     /// The "content:encoded" field
@@ -90,8 +90,11 @@ public class Rss20FeedItem : BaseFeedItem
         DC = new DublinCore(item);
         Source = new FeedItemSource(item.GetElement("source"));
 
-        var categories = item.GetElements("category");
-        Categories = categories.Select(x => x.Value).ToArray();
+        Categories = item
+            .GetElements("category")
+            .Select(ce => new Rss20FeedCategory(ce))
+            .Where(r2fc => !string.IsNullOrWhiteSpace(r2fc.Content))
+            .ToArray();
 
         Guid = item.GetChildElementValue("guid");
         Description = item.GetChildElementValue("description");
@@ -111,7 +114,7 @@ public class Rss20FeedItem : BaseFeedItem
             PublishingDateString = PublishingDateString,
         };
 
-        fi.Categories.AddRange(Categories);
+        fi.Categories.AddRange(Categories.Select(c => c.Content!));
 
         return fi;
     }

--- a/src/Sagara.FeedReader/Feeds/Atom/AtomFeed.cs
+++ b/src/Sagara.FeedReader/Feeds/Atom/AtomFeed.cs
@@ -16,7 +16,7 @@ public class AtomFeed : BaseFeed
     /// <summary>
     /// All "category" elements
     /// </summary>
-    public IReadOnlyCollection<string> Categories { get; private set; } = Array.Empty<string>();
+    public IReadOnlyCollection<AtomFeedCategory> Categories { get; private set; } = Array.Empty<AtomFeedCategory>();
 
     /// <summary>
     /// The "contributor" element
@@ -91,8 +91,11 @@ public class AtomFeed : BaseFeed
 
         Author = new AtomPerson(feed.GetElement("author"));
 
-        var categories = feed.GetElements("category");
-        Categories = categories.Select(x => x.Value).ToArray();
+        Categories = feed
+            .GetElements("category")
+            .Select(ce => new AtomFeedCategory(ce))
+            .Where(afc => !string.IsNullOrWhiteSpace(afc.Term))
+            .ToArray();
 
         Contributor = new AtomPerson(feed.GetElement("contributor"));
         Generator = feed.GetChildElementValue("generator");

--- a/src/Sagara.FeedReader/Feeds/Atom/AtomFeedCategory.cs
+++ b/src/Sagara.FeedReader/Feeds/Atom/AtomFeedCategory.cs
@@ -1,0 +1,48 @@
+﻿using System.Xml.Linq;
+using Sagara.FeedReader.Extensions;
+
+namespace Sagara.FeedReader.Feeds;
+
+/// <summary>
+/// Atom feed category according to specification: https://validator.w3.org/feed/docs/rss2.html
+/// </summary>
+public class AtomFeedCategory : BaseFeedCategory
+{
+    /// <summary>
+    /// The term attribute is a string that identifies the category to which the entry or feed belongs.
+    /// </summary>
+    public string? Term { get; set; }
+
+    /// <summary>
+    /// Optional. Identifies  the categorization scheme associated with this category. This attribute 
+    /// can be used, for example, to differentiate between tags and categories.
+    /// </summary>
+    public string? Scheme { get; set; }
+
+    /// <summary>
+    /// Optional. Provides a human-readable label for display in end-user applications.
+    /// </summary>
+    public string? Label { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AtomFeedCategory"/> class.
+    /// default constructor (for serialization)
+    /// </summary>
+    public AtomFeedCategory()
+        : base()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AtomFeedCategory"/> class.
+    /// Reads a new feed category element based on the given xml item.
+    /// </summary>
+    /// <param name="categoryElement">The xml containing the feed item</param>
+    public AtomFeedCategory(XElement categoryElement)
+        : base(categoryElement)
+    {
+        Term = categoryElement.GetAttributeValue("term");
+        Scheme = categoryElement.GetAttributeValue("scheme");
+        Label = categoryElement.GetAttributeValue("label");
+    }
+}

--- a/src/Sagara.FeedReader/Feeds/Atom/AtomFeedItem.cs
+++ b/src/Sagara.FeedReader/Feeds/Atom/AtomFeedItem.cs
@@ -16,7 +16,7 @@ public class AtomFeedItem : BaseFeedItem
     /// <summary>
     /// All "category" elements
     /// </summary>
-    public IReadOnlyCollection<string> Categories { get; private set; } = Array.Empty<string>();
+    public IReadOnlyCollection<AtomFeedCategory> Categories { get; private set; } = Array.Empty<AtomFeedCategory>();
 
     /// <summary>
     /// The "content" element
@@ -96,9 +96,8 @@ public class AtomFeedItem : BaseFeedItem
 
         Categories = item
             .GetElements("category")
-            .Select(ce => ce.GetAttributeValue("term"))
-            .Where(t => !string.IsNullOrWhiteSpace(t))
-            .Select(t => t!)
+            .Select(ce => new AtomFeedCategory(ce))
+            .Where(afc => !string.IsNullOrWhiteSpace(afc.Term))
             .ToArray();
 
         Content = item.GetChildElementValue("content").HtmlDecode();
@@ -133,7 +132,7 @@ public class AtomFeedItem : BaseFeedItem
             PublishingDateString = PublishedDateString,
         };
 
-        fi.Categories.AddRange(Categories);
+        fi.Categories.AddRange(Categories.Select(afc => afc.Term!));
 
         return fi;
     }

--- a/src/Sagara.FeedReader/Feeds/Base/BaseFeedCategory.cs
+++ b/src/Sagara.FeedReader/Feeds/Base/BaseFeedCategory.cs
@@ -1,0 +1,35 @@
+﻿using System.Xml.Linq;
+
+namespace Sagara.FeedReader.Feeds;
+
+/// <summary>
+/// The base object for all feed categories. Since the RSS 2.0 and Atom <c>category</c> elements differ,
+/// hydrating the object is done in feed-specific subclasses.
+/// </summary>
+public class BaseFeedCategory
+{
+    /// <summary>
+    /// The <c>Category</c> (RSS) or <c>entry</c> (Atom) element from the feed. Return as an XElement in order to 
+    /// allow reading properties that are not available as first-class properties in the derived class itself.
+    /// </summary>
+    public XElement? CategoryElement { get; }
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BaseFeedCategory"/> class.
+    /// default constructor (for serialization)
+    /// </summary>
+    protected BaseFeedCategory()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BaseFeedCategory"/> class.
+    /// Reads a base feed item based on the xml given in element
+    /// </summary>
+    /// <param name="categoryElement">The <c>category</c> element from the feed.</param>
+    public BaseFeedCategory(XElement categoryElement)
+    {
+        CategoryElement = categoryElement;
+    }
+}


### PR DESCRIPTION
This allows callers to filter categories/tags, and supports the schema differences between Atom and RSS 2.0.